### PR TITLE
Update [ resPathLed ] to resPathLed in multiserver2.js

### DIFF
--- a/ocf-servers/zjs-servers/multiserver2.js
+++ b/ocf-servers/zjs-servers/multiserver2.js
@@ -38,7 +38,7 @@ var led = gpio.open({ pin: 'LED2', mode: 'out', activeLow: false }),
         value: (led.read() != 0)? true : false
     },
     ledResourceInit = {
-        resourcePath : [ resPathLed ],
+        resourcePath : resPathLed,
         resourceTypes: [ resTypeLed ],
         interfaces   : [ 'oic.if.baseline' ],
         discoverable : true,


### PR DESCRIPTION
Singed-off-by: Zhang Xiaoyu <xiaoyux.zhang@intel.com>

Type| Pass | Fail |Block | Comment 
---| ---| ---| ---|--- 
manual | 1 | 0| 0 |  

Code `resourcePath : resPathLed ` is writed as `resourcePath : [ resPathLed ]` in PR #194, so submit this PR to update this mistake.   